### PR TITLE
remove PWM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It supports up to 4 radio channels and 4 selectable device IDs.
 
 ## Hardware requirements
 
-This project was developed using the Arduino Nano V3, and a compatible board with integrated nRF24L01 radio. Some other Arduinos may work, but they must have analog input pin A7. So, for instance, the Uno won't work.
+This project was developed using the Arduino Nano V3, and a compatible board with integrated nRF24L01 radio. Some other Arduinos may work as well. Note PWM support has been removed in this branch, so a device lacking pin A7 for PWM support can be used.
 
 ## Software requirements
 
@@ -50,13 +50,9 @@ Here are the descriptions of each pin. All INPUT_PULLUP pins are active-low acco
 | A4  | INPUT_PULLUP | device ID, bit 1       |
 | A5  | INPUT_PULLUP | device ID, bit 0       |
 | A6  | unused       |                        |
-| A7  | INPUT        | sets output PWM        |
+| A7  | unused       | PWM support removed    |
 
 \* refer to `morse.cpp:setupRadio()`
-
-### PWM wiring (pin A7)
-
-The output pins support PWM. This is controlled by the voltage on pin A7, which is usually wired to +5V. If you leave A7 unconnected, you will get erratic results. On the Nano V3, it is easy to wire A7 to +5V because the two pins are right next to each other. In most cases that's what you will do unless you really want to use PWM.
 
 ### Indicator LED
 

--- a/morse/morse.cpp
+++ b/morse/morse.cpp
@@ -173,15 +173,9 @@ void errExit() {
   exit(1);
 }
 
-int getPWM() {
-  double pwmRaw = analogRead(PIN_PWM); // 0 to 2^10 - 1
-  return pwmRaw / 4;
-}
-
 void setOutput(bool value) {
-  int pwmWidth = getPWM();
-  analogWrite(PIN_OUT, value * pwmWidth);
-  analogWrite(PIN_OUT_, 255 - (value * pwmWidth));
+  digitalWrite(PIN_OUT, value);
+  digitalWrite(PIN_OUT_,!value);
 }
 
 bool buttonPressed() {

--- a/morse/morse.h
+++ b/morse/morse.h
@@ -42,10 +42,6 @@ const uint64_t DEVICE_ID_BASE = 0x600DFF2440LL;
 const int PIN_ID2 = A4; // if wired low, add 0x2 to ID_BASE
 const int PIN_ID1 = A5; // if wired low, add 0x1 to ID_BASE
 
-// analog input for PWM
-// Usually you would wire this to +5V (it's right next to the +5V pin)
-const int PIN_PWM = A7;
-
 // These wirings of CE, CSN are used for integrated Nano3/nRF24l01 boards
 const int PIN_CE = 10;
 const int PIN_CSN = 9;
@@ -132,8 +128,6 @@ void readSpeedFromEEPROM();
 void writePauseToEEPROM();
 
 void readPauseFromEEPROM();
-
-int getPWM();
 
 void setOutput(bool value);
 

--- a/morse/morse.ino
+++ b/morse/morse.ino
@@ -42,13 +42,6 @@ void setup() {
   
   pinMode(PIN_XRMODE, INPUT_PULLUP);
   transmitMode = digitalRead(PIN_XRMODE);
-  
-  pinMode(PIN_PWM, INPUT);
-
-  int pwm = getPWM();
-  if (pwm < 255) {
-    Serial.print(F("Warning: PWM = ")); Serial.println(pwm);
-  }
 
   // channel jumpers
   pinMode(PIN_CH10, INPUT_PULLUP);


### PR DESCRIPTION
Remove support for PWM. This accommodates Arduino Uno and other compatible boards that lack an A7 analog input pin.